### PR TITLE
Return query for args.query, not querystring

### DIFF
--- a/seneca-web-adapter-koa1.js
+++ b/seneca-web-adapter-koa1.js
@@ -19,7 +19,7 @@ module.exports = function koa (options, context, auth, routes, done) {
           body = yield Parse(this)
         }
 
-        const query = this.request.querystring
+        const query = Object.assign({}, this.request.query)
 
         const payload = {
           request$: this.request,

--- a/test/seneca-web-adapter-koa1.test.js
+++ b/test/seneca-web-adapter-koa1.test.js
@@ -94,6 +94,38 @@ describe('koa', () => {
     })
   })
 
+  it('querystring', done => {
+    var config = {
+      routes: {
+        pin: 'role:test,cmd:*',
+        map: {
+          echo: {GET: true}
+        }
+      }
+    }
+
+    si.use(Web, {adapter: require('..'), context: Router()})
+
+    si.add('role:test,cmd:echo', (msg, reply) => {
+      reply(null, msg.args.query)
+    })
+
+    si.act('role:web', config, (err, reply) => {
+      if (err) return done(err)
+
+      app.use(si.export('web/context')().routes())
+
+      Request.get('http://127.0.0.1:3000/echo?foo=bar', (err, res, body) => {
+        if (err) return done(err)
+
+        body = JSON.parse(body)
+
+        expect(body).to.be.equal({foo: 'bar'})
+        done()
+      })
+    })
+  })
+
   it('post requests', (done) => {
     var config = {
       routes: {


### PR DESCRIPTION
Fixes #9 

Also, seems that `this.request.query` is not a plain object according to lodash (probably no prototype?) so need to run it through `Object.assign` for it to be returned properly.